### PR TITLE
Remove hardcoded protocol

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -107,7 +107,7 @@
   serverRequire = function(path, callback) {
     var request;
     request = new XMLHttpRequest();
-    request.open('GET', "http://" + requestHostname + ":" + requestPort + "/mundlejs" + path + "?" + (cacheDiffString()), true);
+    request.open('GET', "//" + requestHostname + ":" + requestPort + "/mundlejs" + path + "?" + (cacheDiffString()), true);
     request.responseType = 'text';
     request.onload = function() {
       var response;

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -97,7 +97,7 @@ requestPort = window.location.port
 # looks like: http://<location.hostname>:<location.port>/mundlejs</file requested>?alreadyLoadedModule=1&anotherAlreadyLoaded=1&.....
 serverRequire = (path, callback)->
   request = new XMLHttpRequest()
-  request.open('GET', "http://#{requestHostname}:#{requestPort}/mundlejs#{path}?#{cacheDiffString()}", true)
+  request.open('GET', "//#{requestHostname}:#{requestPort}/mundlejs#{path}?#{cacheDiffString()}", true)
   # request.setRequestHeader 'clientid', 'lakjsdflkjasld'
   request.responseType = 'text'
   request.onload = ->


### PR DESCRIPTION
The client will currently only request files on http:// even if the site serving them is https://. A commonly used trick to support the protocol of the current page is to simply leave out the protocol and start the URL with "//".
